### PR TITLE
Fix: Remove deprecated access_control field from project creation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -298,7 +298,8 @@ async function run() {
                 newProjectId = options.projectmap[project.id]
             } else {
                 try {
-                    newproject = await destination.path('/api/projects/').method('post').create()(project)
+                    const { access_control, ...projectWithoutAccessControl } = project
+                    newproject = await destination.path('/api/projects/').method('post').create()(projectWithoutAccessControl)
                     newProjectId = newproject.data.id
                 } catch (e) {
                     if (e.getActualType && e.getActualType()) {


### PR DESCRIPTION
Removing the deprecated access_control field since it caused the script to fail with the following status 400 error:

The 'access_control' field has been deprecated and is no longer supported. Please use the new access control system instead. For more information, visit: https://posthog.com/docs/settings/access-control