### PR TITLE
Declare ts-node and typescript (pinned to 5.x) as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.ts",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^18.11.9"
+    "@types/node": "^18.11.9",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@types/node-fetch": "2",


### PR DESCRIPTION
## Problem

The README's documented invocation (`ts-node index.ts ...`) assumes `ts-node` and `typescript` are installed, but neither is declared in `package.json`. A fresh install today resolves `typescript` to `latest`, which is now TypeScript 7 — whose JS API no longer exposes `ts.sys` the way ts-node 10.x expects. The tool crashes before parsing any arguments:

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at readConfig (.../node_modules/ts-node/dist/configuration.js:91:33)
    at findAndReadConfig (.../node_modules/ts-node/dist/configuration.js:50:84)
    at phase3 (.../node_modules/ts-node/dist/bin.js:254:67)
```

This hits every new user following the README from now on.

## Fix

Declare `ts-node` and `typescript` as devDependencies, with typescript pinned to `^5.9.3` (ts-node 10.x supports TypeScript 4/5 only). After this, `yarn` (or `npm install`) is sufficient to run the documented command.

Verified on a real US→EU Cloud migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)