### PR TITLE
Strip cohort_type so cohorts migrate against current PostHog Cloud

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,13 @@ class MigrateProjectData {
                     return false
                 }
                 return true
+            },
+            (object) => {
+                // The destination recomputes cohort_type from the filters on create and
+                // rejects a stale value ("Invalid cohort type for the given filters"),
+                // so let it derive the type itself.
+                delete object.cohort_type
+                return object
             }
         )
         await this.migrateObject(


### PR DESCRIPTION
## Problem

Cohort migration currently fails against PostHog Cloud for any non-static cohort. The tool POSTs the source cohort's `cohort_type` verbatim, but the destination's serializer validates that field against the *submitted* filters and rejects mismatches:

```
{
  "type": "validation_error",
  "code": "invalid_input",
  "detail": "Invalid cohort type for the given filters",
  "attr": "cohort_type"
}
```

In a real US→EU Cloud migration, all 3 cohorts failed this way — and because cohorts fail, any feature flag referencing them then crashes the run in `replaceCohortsRecurse`.

## Fix

Delete `cohort_type` from the payload before POSTing. Two facts about the destination's create path make this strictly safe:

- `validate_cohort_type` returns immediately when the field is absent/empty — validation only runs on a supplied value.
- `create()` recomputes `cohort_type` from the filters regardless (`validated_data["cohort_type"] = computed_cohort_type`), so the submitted value never survives anyway.

Verified on a real US→EU Cloud migration: all 3 previously-failing cohorts migrated cleanly after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)