### PR TITLE
Remap flag-to-flag dependencies when migrating feature flags

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import './fetch-polyfill'
 import { Fetcher, Middleware } from 'openapi-typescript-fetch'
 
 import { paths } from './posthogapi'
-import { replaceCohortsRecurse, State } from './utils';
+import { replaceCohortsRecurse, replaceFlagDependenciesRecurse, State } from './utils';
 import * as commandLineArgs from 'command-line-args'
 
 
@@ -127,6 +127,12 @@ class MigrateProjectData {
             },
             (object) => {
                 replaceCohortsRecurse(object.filters, this.state['cohorts'])
+                try {
+                    replaceFlagDependenciesRecurse(object.filters, this.state['feature_flags'])
+                } catch (e) {
+                    console.warn(`Feature flag "${object.key}" (ID ${object.id}) skipped: ${e.message}. Re-run once the flag it depends on has been migrated.`)
+                    return null
+                }
                 return object
             }
         )

--- a/utils.ts
+++ b/utils.ts
@@ -21,6 +21,30 @@ export const replaceCohortsRecurse = function(object, state) {
         }
     }
 
+// Flag-dependency properties ({type: 'flag'}) reference other flags by numeric ID
+// in their `key` field, so the IDs must be rewritten to the destination's.
+export const replaceFlagDependenciesRecurse = function(object, state) {
+        if (Array.isArray(object)) {
+            for (let i = 0; i < object.length; i++) {
+                replaceFlagDependenciesRecurse(object[i], state);
+            }
+        }
+        else if (typeof object === "object" && object) {
+            if(object['type'] && object.type === 'flag' && object['key']) {
+                if(!state[object['key']]) {
+                    throw Error(`depends on flag ${object.key}, which has no destination mapping yet`)
+                }
+                // The flags evaluation service parses this key strictly as a string;
+                // a numeric value breaks config parsing for the entire project.
+                object.key = String(state[object['key']])
+            } else {
+                for (const key in object) {
+                    replaceFlagDependenciesRecurse(object[key], state);
+                }
+            }
+        }
+    }
+
 export class State {
     state: Record<any, any>
     options: Record<any, any>


### PR DESCRIPTION
## Problem

Feature flags can depend on other flags, referenced by numeric ID inside `filters` (`{"type": "flag", "key": <flag id>, "operator": "flag_evaluates_to", ...}`). The tool copies these properties verbatim with **source** instance IDs, so the destination rejects every flag that has a dependency:

```
{
  "type": "validation_error",
  "code": "invalid_input",
  "detail": "Flag dependency references non-existent flag with ID 656810",
  "attr": "filters"
}
```

In a real US→EU Cloud migration, 4 of 80 flags failed this way — dependent flags simply cannot be migrated by the current tool.

## Fix

Add `replaceFlagDependenciesRecurse`, mirroring the existing cohort remapping: walk `filters`, and rewrite the `key` of every `{type: "flag"}` property through the state file's `feature_flags` mapping.

Two deliberate details:

1. **The remapped ID is coerced to a string.** This is load-bearing: the REST API accepts an integer `key` (validated via `safe_int`), but the flag *evaluation* service parses the project's entire flag configuration strictly and returns HTTP 500 — for **every flag in the project** — if any dependency key is numeric. We hit exactly this: `/flags?v=2` answered `Failed to parse flag configuration data. This may indicate a misconfigured feature flag.` until the key type was fixed. (Filing the write/evaluate asymmetry separately against PostHog/posthog.)
2. **Unresolvable references skip the flag with a warning instead of crashing the run.** The source flag list isn't topologically sorted, so a dependent can appear before its dependency; it's picked up on a re-run once the dependency is mapped (the run is idempotent via the state file). The same guard prevents the existing failure mode where one bad reference inside `Array.map(mapObjects)` throws uncaught and kills the whole migration. A topological sort would resolve everything in a single pass — happy to add it if you'd prefer that here.

Verified on a real US→EU Cloud migration: all 4 previously-failing dependent flags migrated, with dependencies verified pointing at the correct destination flags, and flag evaluation healthy (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)