### PR TITLE
fix: resolve compile failure and experiments migration crash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,9 +111,11 @@ class MigrateProjectData {
             'experiments',
             null,
             (object) => {
-                replaceCohortsRecurse(object.filters, this.state['cohorts'])
-                for (let i = 0; i < object.filters.actions?.length; i++) {
-                    object.filters.actions[i].id = this.state['actions'][object.filters.actions[i].id]
+                if (object.filters) {
+                    replaceCohortsRecurse(object.filters, this.state['cohorts'])
+                    for (let i = 0; i < object.filters.actions?.length; i++) {
+                        object.filters.actions[i].id = this.state['actions'][object.filters.actions[i].id]
+                    }
                 }
                 return object
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.ts",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^18.11.9"
+    "@types/node": "^18.11.9",
+    "typescript": "^5.4.5",
+    "ts-node": "^10.9.2"
   },
   "dependencies": {
     "@types/node-fetch": "2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
-    "lib": [ "es2015", "DOM" ]
+    "lib": [ "es2020", "DOM" ]
   }
 }


### PR DESCRIPTION
## Summary

Two independent issues that block `ts-node index.ts ...` from working end-to-end:

**1. Compile failure before the script can run**

`index.ts` uses `Object.fromEntries()` (ES2019) and optional chaining (`?.`), but `tsconfig.json`'s `lib` was capped at `es2015` (missing the `fromEntries` typings regardless of TypeScript version), and neither `typescript` nor `ts-node` were pinned in `package.json`, so compilation depended entirely on whatever global version a user had installed:

```
index.ts (38,33): Property 'fromEntries' does not exist on type 'ObjectConstructor'.
index.ts (115,60): Expression expected.
```

Fix: widen `tsconfig.json`'s `lib` to `es2020`, and pin `typescript`/`ts-node` as `devDependencies` so `yarn install` gives everyone a known-good compiler.

**2. Runtime crash during the experiments migration step**

Once compiling, the script crashes partway through with:

```
TypeError: Cannot read properties of undefined (reading 'actions')
    at index.ts:115:52
```

The experiments list is fetched with `basic=true`, and the basic/list serializer PostHog uses for that mode omits the legacy `filters` field (only the detail serializer includes it). The experiments mapper assumed `object.filters` was always present, guarding only `.actions` and not `filters` itself.

Fix: skip the cohort/action-id rewrite when `filters` isn't present instead of assuming it always is.

Verified locally against the actual repo source: reproduced the exact `fromEntries` compile error with the original `lib` setting and confirmed it disappears after widening it, and confirmed a modern TypeScript compiler parses the optional chaining without issue.